### PR TITLE
Update lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "main": "index.min.js",
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash": "4.17.5"
   },
   "devDependencies": {
     "grunt": "~1.0",


### PR DESCRIPTION
Per https://nodesecurity.io/advisories/577 lodash needs to be updated to >=4.17.5